### PR TITLE
reduce the # of allocations using pools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test:
 
 .PHONY: benchmark
 benchmark:
-	${GOCMD} test -run=^$$ -bench=${benchname} -v -cpuprofile ${profile} -benchmem -benchtime=${benchtime} -timeout=90s ${pkg}
+	${GOCMD} test -run=^$$ -bench=${benchname} -v -cpuprofile ${profile}.cpu -memprofile ${profile}.mem -benchmem -benchtime=${benchtime} -timeout=90s ${pkg}
 	@echo "Benchmark profile saved at: ${profile}"
 
 .PHONY: fmt

--- a/pkg/client/min_max.go
+++ b/pkg/client/min_max.go
@@ -129,6 +129,7 @@ func (h *Heuristic) alphabeta(ctx context.Context, tt *transpositionTable, state
 	}
 
 	coups := h.generateCoups(state, race)
+	defer putCoups(coups)
 	if len(coups) == 0 { // or no more moves found
 		value := h.scoreState(state)
 		return bestCoup, value
@@ -158,6 +159,8 @@ func (h *Heuristic) alphabeta(ctx context.Context, tt *transpositionTable, state
 			value = score
 			bestCoup = coup
 			// log.Printf("better value found %f: depth: %d, race: %v", value, depth, race)
+		} else {
+			putCoup(coup)
 		}
 
 		// Check for possible cuts


### PR DESCRIPTION
Before / After:

```
benchmark                           old ns/op      new ns/op      delta
BenchmarkAB/depth2_complex-8        5978416        4949904        -17.20%
BenchmarkAB/depth3_complex-8        151444489      68777047       -54.59%
BenchmarkAB/depth4_complex-8        954851044      345197624      -63.85%
BenchmarkAB/depth5_complex-8        5336734807     3048691151     -42.87%
BenchmarkAB/timeout2s_complex-8     2000168178     2000138784     -0.00%
BenchmarkAB/depth2_simple-8         89905          110177         +22.55%
BenchmarkAB/depth3_simple-8         728034         810756         +11.36%
BenchmarkAB/depth4_simple-8         4345249        4484112        +3.20%
BenchmarkAB/depth5_simple-8         26100989       21839310       -16.33%
BenchmarkAB/depth6_simple-8         101811347      78366774       -23.03%
BenchmarkAB/timeout2s_simple-8      2000127530     2000135178     +0.00%

benchmark                           old allocs     new allocs     delta
BenchmarkAB/depth2_complex-8        9607           9994           +4.03%
BenchmarkAB/depth3_complex-8        232285         133966         -42.33%
BenchmarkAB/depth4_complex-8        1758557        734442         -58.24%
BenchmarkAB/depth5_complex-8        11402352       4892018        -57.10%
BenchmarkAB/timeout2s_complex-8     4370774        4026244        -7.88%
BenchmarkAB/depth2_simple-8         357            348            -2.52%
BenchmarkAB/depth3_simple-8         2716           2641           -2.76%
BenchmarkAB/depth4_simple-8         18102          15588          -13.89%
BenchmarkAB/depth5_simple-8         98722          75771          -23.25%
BenchmarkAB/depth6_simple-8         406994         290258         -28.68%
BenchmarkAB/timeout2s_simple-8      8726130        6202409        -28.92%

benchmark                           old bytes     new bytes     delta
BenchmarkAB/depth2_complex-8        529178        297048        -43.87%
BenchmarkAB/depth3_complex-8        10624552      4183715       -60.62%
BenchmarkAB/depth4_complex-8        88596964      19427012      -78.07%
BenchmarkAB/depth5_complex-8        569713088     144779792     -74.59%
BenchmarkAB/timeout2s_complex-8     226380180     117431016     -48.13%
BenchmarkAB/depth2_simple-8         12482         11169         -10.52%
BenchmarkAB/depth3_simple-8         105528        90907         -13.86%
BenchmarkAB/depth4_simple-8         745357        487190        -34.64%
BenchmarkAB/depth5_simple-8         4254258       2323032       -45.40%
BenchmarkAB/depth6_simple-8         19576186      8024495       -59.01%
BenchmarkAB/timeout2s_simple-8      431368920     171032300     -60.35%
```