### PR TITLE
when calling Play we should always pass a copy of the state and never the game itself

### DIFF
--- a/cmd/auto/main.go
+++ b/cmd/auto/main.go
@@ -50,7 +50,7 @@ func main() {
 	go server.StartServer(mapPath, useRand, rows, columns, humans, monster, time.Duration(timeoutS)*time.Second, false, nil, false, nil)
 
 	p1 := client.NewMinMaxIA(1500 * time.Millisecond)
-	p2 := client.NewMinMaxIA(500 * time.Millisecond)
+	p2 := client.NewDumbIA()
 
 	addr := "localhost:5555"
 	player1, err := client.NewTCPClient(addr, p1.Name(), p1)

--- a/pkg/client/heuristic.go
+++ b/pkg/client/heuristic.go
@@ -94,6 +94,9 @@ func getCoups() []model.Coup {
 // Heuristic represents a heuristic
 type Heuristic struct {
 	HeuristicParameters
+
+	// Used to avoid reallocations when computing a state hash
+	hashBuffer []uint32
 }
 
 func (h *Heuristic) String() string {
@@ -102,7 +105,7 @@ func (h *Heuristic) String() string {
 
 // NewHeuristic creates a new heuristic given parameters
 func NewHeuristic(params HeuristicParameters) Heuristic {
-	return Heuristic{params}
+	return Heuristic{params, make([]uint32, 0, 32)}
 }
 
 // randomMove gives a random move among the possible moves for the race Ally

--- a/pkg/client/min_max.go
+++ b/pkg/client/min_max.go
@@ -118,7 +118,7 @@ func (h *Heuristic) alphabeta(ctx context.Context, tt *transpositionTable, state
 	default:
 	}
 
-	hash := state.Hash(race)
+	hash := state.Hash(race, h.hashBuffer)
 
 	rec, cached := tt.get(hash, maxDepth)
 	if cached {

--- a/pkg/client/min_max_ia.go
+++ b/pkg/client/min_max_ia.go
@@ -22,7 +22,7 @@ func NewMinMaxIA(timeout time.Duration) *MinMaxIA {
 }
 
 func (m *MinMaxIA) Play(state *model.State) model.Coup {
-	return m.heuristic.findBestCoupWithTimeout(state, m.timeout)
+	return m.heuristic.findBestCoupWithTimeout(state.Copy(false), m.timeout)
 }
 
 func (m *MinMaxIA) Name() string {

--- a/pkg/client/min_max_test.go
+++ b/pkg/client/min_max_test.go
@@ -427,7 +427,7 @@ func BenchmarkHash(b *testing.B) {
 	startState := model.GenerateComplicatedState()
 
 	for n := 0; n < b.N; n++ {
-		startState.Hash(model.Ally)
+		startState.Hash(model.Ally, testHeuristic.hashBuffer)
 	}
 }
 

--- a/pkg/client/model/state_test.go
+++ b/pkg/client/model/state_test.go
@@ -1,10 +1,11 @@
 package model
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkSortStd(b *testing.B) {
@@ -50,7 +51,7 @@ func TestHashing(t *testing.T) {
 	s2.SetCell(Coordinates{2, 2}, Neutral, 7)
 	s2.SetCell(Coordinates{7, 4}, Enemy, 75)
 
-	assert.NotEqual(t, s1.Hash(Ally), s2.Hash(Ally))
+	assert.NotEqual(t, s1.Hash(Ally, nil), s2.Hash(Ally, nil))
 }
 
 func TestSort(t *testing.T) {


### PR DESCRIPTION
+ Make `hashBuffer` a heuristic attribute to avoid data races when we run multiple IAs in //

This fixes the panics like the following one that can occur when we run tournaments:

panic: Tried to decrease population at non existing cell: {X:1 Y:3}
```
goroutine 83 [running]:
github.com/langorou/langorou/pkg/client/model.(*State).DecreaseCell(0xc00055d9e0, 0xc006010301)
  /home/baloo/codes/go/src/github.com/langorou/langorou/pkg/client/model/state.go:156 +0x43f
github.com/langorou/langorou/pkg/client/model.(*State).ApplyCoup(0xc00021c000, 0x1, 0xc0005d9150, 0x1, 0x1, 0x3ff0000000000000, 0xffefffffffffffff, 0x0, 0x701)
  /home/baloo/codes/go/src/github.com/langorou/langorou/pkg/client/model/simulator.go:29 +0x2ed
github.com/langorou/langorou/pkg/client.(*Heuristic).alphabeta(0xc00015e058, 0x9016c0, 0xc00012c0c0, 0xc0002c1d90, 0xc00021c000, 0x1, 0x0, 0x7fefffffffffffff, 0x700, 0x0, ...)
  /home/baloo/codes/go/src/github.com/langorou/langorou/pkg/client/min_max.go:156 +0x632
github.com/langorou/langorou/pkg/client.(*Heuristic).findBestCoupWithTimeout.func1(0x9016c0, 0xc00012c0c0, 0xc00015e058, 0xc00021c000, 0xc000120120)
  /home/baloo/codes/go/src/github.com/langorou/langorou/pkg/client/min_max.go:74 +0x14a
created by github.com/langorou/langorou/pkg/client.(*Heuristic).findBestCoupWithTimeout
  /home/baloo/codes/go/src/github.com/langorou/langorou/pkg/client/min_max.go:67 +0x11e
```